### PR TITLE
Adding support for v12 and further improvements

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,46 +1,47 @@
 {
-	"id": "Waterdeep-City-of-Splendors",
-	"title": "Waterdeep - City of Splendors",
-	"description": "A full Waterdeep map with all locations as presented by https://www.aidedd.org/",
-	"version": "1.4.1",
-	"compatibility": {
-		"minimum": "11",
-		"verified": "11"
-	},
-	"authors": [
-		{
-			"name": "Gage Eakins"
-		}
-	],
-	"packs": [
-		{
-			"name": "maps",
-			"label": "Waterdeep - City of Splendors",
-			"path": "/packs/maps",
-			"type": "Scene",
-			"module": "Waterdeep-City-of-Splendors"
-		},
-		{
-			"name": "journals",
-			"label": "Waterdeep - City of Splendors",
-			"path": "/packs/journals",
-			"type": "JournalEntry",
-			"module": "Waterdeep-City-of-Splendors"
-		}
-	],
-	"esmodules": [
-		"./scripts/init.js"
-	],
-	"relationships": {
-		"requires": [
-			{
-				"id": "scene-packer",
-				"type": "module",
-				"manifest": "https://github.com/League-of-Foundry-Developers/scene-packer/releases/latest/download/module.json"
-			}
-		]
-	},	
-	"url": "https://github.com/webmaster94/Waterdeep-City-of-Splendors",
-	"manifest": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/latest/download/module.json",
-	"download": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/download/v1.4/Waterdeep-City-of-Splendors.zip"
+    "id": "Waterdeep-City-of-Splendors",
+    "title": "Waterdeep - City of Splendors",
+    "description": "A full Waterdeep map with all locations as presented by https://www.aidedd.org/",
+    "version": "3.0",
+    "compatibility": {
+        "minimum": "12",
+        "verified": "12"
+    },
+    "authors": [
+        {
+            "name": "Gage Eakins"
+        }
+    ],
+    "packs": [
+        {
+            "name": "maps",
+            "label": "Waterdeep - City of Splendors",
+            "path": "/packs/maps",
+            "type": "Scene",
+            "module": "Waterdeep-City-of-Splendors"
+        },
+        {
+            "name": "journals",
+            "label": "Waterdeep - City of Splendors",
+            "path": "/packs/journals",
+            "type": "JournalEntry",
+            "module": "Waterdeep-City-of-Splendors"
+        }
+    ],
+    "esmodules": [
+        "./scripts/init.js",
+        "./scripts/waterdeep.js"
+    ],
+    "relationships": {
+        "requires": [
+            {
+                "id": "scene-packer",
+                "type": "module",
+                "manifest": "https://github.com/League-of-Foundry-Developers/scene-packer/releases/latest/download/module.json"
+            }
+        ]
+    },
+    "url": "https://github.com/webmaster94/Waterdeep-City-of-Splendors",
+    "manifest": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/latest/download/module.json",
+    "download": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/download/v3.0/Waterdeep-City-of-Splendors.zip"
 }


### PR DESCRIPTION
This commit adds support for Foundry VTT v12 to the Waterdeep-City-of-Splendors. 

Changes: 

- Executing the script after packs have been added. This allow the execution to use the folders and everything by the packs. 
- Adding 2 functions to allow managing the folders via code: `getFoldersIdsByNames` and `getIdByName`. The idea is to manage everything by changing the variable `folderNames` if required. 
- Modified the addData function to deal with duplicated data and adding entry pages to the existing journal entries. 
- Modifying the verified version of Foundry as I tested it on my local instance.
